### PR TITLE
SERVER-21645 RocksRecordStore::temp_cappedTruncateAfter should set _oplog_highestSeen

### DIFF
--- a/src/rocks_record_store.cpp
+++ b/src/rocks_record_store.cpp
@@ -141,6 +141,11 @@ namespace mongo {
         }
     }
 
+    void CappedVisibilityManager::setHighestSeen(const RecordId& record) {
+        stdx::lock_guard<stdx::mutex> lk(_lock);
+        _oplog_highestSeen = record;
+    }
+
     RecordId CappedVisibilityManager::oplogStartHack() const {
         stdx::lock_guard<stdx::mutex> lk(_lock);
         if (_uncommittedRecords.empty()) {
@@ -824,6 +829,16 @@ namespace mongo {
                                                      bool inclusive ) {
         // copied from WiredTigerRecordStore::temp_cappedTruncateAfter()
         WriteUnitOfWork wuow(txn);
+        RecordId lastKeptId = end;
+        int64_t recordsRemoved = 0;
+
+        if (inclusive) {
+            auto reverseCursor = getCursor(txn, false);
+            invariant(reverseCursor->seekExact(end));
+            auto prev = reverseCursor->next();
+            lastKeptId = prev ? prev->id : RecordId::min();
+        }
+
         auto cursor = getCursor(txn, true);
         for (auto record = cursor->seekExact(end); record; record = cursor->next()) {
             if (end < record->id || (inclusive && end == record->id)) {
@@ -832,8 +847,15 @@ namespace mongo {
                         _cappedCallback->aboutToDeleteCapped(txn, record->id, record->data));
                 }
                 deleteRecord(txn, record->id);
+                ++recordsRemoved;
             }
         }
+
+        if (recordsRemoved) {
+            // Forget that we've ever seen a higher timestamp than we now have.
+            _cappedVisibilityManager->setHighestSeen(lastKeptId);
+        }
+
         wuow.commit();
     }
 

--- a/src/rocks_record_store.h
+++ b/src/rocks_record_store.h
@@ -61,6 +61,7 @@ namespace mongo {
             : _cappedCallback(cappedCallback), _oplog_highestSeen(RecordId::min()) {}
         void dealtWithCappedRecord(const RecordId& record);
         void updateHighestSeen(const RecordId& record);
+        void setHighestSeen(const RecordId& record);
         void addUncommittedRecord(OperationContext* txn, const RecordId& record);
 
         // a bit hacky function, but does the job

--- a/src/rocks_record_store_test.cpp
+++ b/src/rocks_record_store_test.cpp
@@ -486,10 +486,70 @@ namespace mongo {
         }
 
         {
-            // now we insert 2 docs, but commit the 2nd one fiirst
-            // we make sure we can't find the 2nd until the first is commited
+            // now we insert 2 docs, but commit the 2nd one first.
+            // we make sure we can't find the 2nd until the first is committed.
+            std::unique_ptr<OperationContext> earlyReader(harnessHelper->newOperationContext());
+            auto earlyCursor = rs->getCursor(earlyReader.get());
+            ASSERT_EQ(earlyCursor->seekExact(loc1)->id, loc1);
+            earlyCursor->save();
+            earlyReader->recoveryUnit()->abandonSnapshot();
+
             std::unique_ptr<OperationContext> t1( harnessHelper->newOperationContext() );
-            std::unique_ptr<WriteUnitOfWork> w1( new WriteUnitOfWork( t1.get() ) );
+            WriteUnitOfWork w1(t1.get());
+            _oplogOrderInsertOplog(t1.get(), rs, 20);
+            // do not commit yet
+
+            {  // create 2nd doc
+                std::unique_ptr<OperationContext> t2(harnessHelper->newOperationContext());
+                {
+                    WriteUnitOfWork w2(t2.get());
+                    _oplogOrderInsertOplog(t2.get(), rs, 30);
+                    w2.commit();
+                }
+            }
+
+            {  // Other operations should not be able to see 2nd doc until w1 commits.
+                earlyCursor->restore();
+                ASSERT(!earlyCursor->next());
+
+                std::unique_ptr<OperationContext> opCtx(harnessHelper->newOperationContext());
+                auto cursor = rs->getCursor(opCtx.get());
+                auto record = cursor->seekExact(loc1);
+                ASSERT_EQ(loc1, record->id);
+                ASSERT(!cursor->next());
+            }
+
+            w1.commit();
+        }
+
+        {  // now all 3 docs should be visible
+            std::unique_ptr<OperationContext> opCtx(harnessHelper->newOperationContext());
+            auto cursor = rs->getCursor(opCtx.get());
+            auto record = cursor->seekExact(loc1);
+            ASSERT_EQ(loc1, record->id);
+            ASSERT(cursor->next());
+            ASSERT(cursor->next());
+            ASSERT(!cursor->next());
+        }
+
+        // Rollback the last two oplog entries, then insert entries with older optimes and ensure that
+        // the visibility rules aren't violated. See SERVER-21645
+        {
+            std::unique_ptr<OperationContext> txn(harnessHelper->newOperationContext());
+            rs->temp_cappedTruncateAfter(txn.get(), loc1, /*inclusive*/ false);
+        }
+
+        {
+            // Now we insert 2 docs with timestamps earlier than before, but commit the 2nd one first.
+            // We make sure we can't find the 2nd until the first is commited.
+            std::unique_ptr<OperationContext> earlyReader(harnessHelper->newOperationContext());
+            auto earlyCursor = rs->getCursor(earlyReader.get());
+            ASSERT_EQ(earlyCursor->seekExact(loc1)->id, loc1);
+            earlyCursor->save();
+            earlyReader->recoveryUnit()->abandonSnapshot();
+
+            std::unique_ptr<OperationContext> t1(harnessHelper->newOperationContext());
+            WriteUnitOfWork w1(t1.get());
             _oplogOrderInsertOplog( t1.get(), rs, 2 );
             // do not commit yet
 
@@ -502,7 +562,10 @@ namespace mongo {
                 }
             }
 
-            { // state should be the same
+            {  // Other operations should not be able to see 2nd doc until w1 commits.
+                ASSERT(earlyCursor->restore());
+                ASSERT(!earlyCursor->next());
+
                 std::unique_ptr<OperationContext> opCtx( harnessHelper->newOperationContext() );
                 auto cursor = rs->getCursor(opCtx.get());
                 auto record = cursor->seekExact(loc1);
@@ -511,7 +574,7 @@ namespace mongo {
                 ASSERT(!cursor->next());
             }
 
-            w1->commit();
+            w1.commit();
         }
 
         { // now all 3 docs should be visible


### PR DESCRIPTION
this is mongo-rocks analog of https://github.com/mongodb/mongo/commit/0e4d706953cd4db25fc9ffa4abf106541157f971