### PR TITLE
SERVER-22245 add missing libdep to storage_rocks_engine_test

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -87,7 +87,8 @@ env.CppUnitTest(
            ],
    LIBDEPS=[
         'storage_rocks_mock',
-        '$BUILD_DIR/mongo/db/storage/kv/kv_engine_test_harness'
+        '$BUILD_DIR/mongo/db/storage/kv/kv_engine_test_harness',
+        '$BUILD_DIR/mongo/db/storage/storage_options'
         ]
    )
 


### PR DESCRIPTION
Hello,

I broke the rocksdb build in commit dafe72f68 on mongodb/master. Adding this libdep edge should fix it.

Best,
Adam