### PR TITLE
Use of SingleDelete for standard index

### DIFF
--- a/src/rocks_index.cpp
+++ b/src/rocks_index.cpp
@@ -818,7 +818,7 @@ namespace mongo {
 
         _indexStorageSize.fetch_sub(static_cast<long long>(prefixedKey.size()),
                                     std::memory_order_relaxed);
-        ru->writeBatch()->Delete(prefixedKey);
+        ru->writeBatch()->SingleDelete(prefixedKey);
     }
 
     std::unique_ptr<SortedDataInterface::Cursor> RocksStandardIndex::newCursor(


### PR DESCRIPTION
Replace `Delete` with `SingleDelete` in `unindex` method of standard index.
This also required adding a check to disallow multiple consecutive `SingleDelete` calls under some circumstances.