### PR TITLE
Use SingleDelete for standard index (take 2, with config option)

### DIFF
--- a/src/rocks_engine.cpp
+++ b/src/rocks_engine.cpp
@@ -375,8 +375,12 @@ namespace mongo {
             index = new RocksUniqueIndex(_db.get(), _getIdentPrefix(ident), ident.toString(),
                                          Ordering::make(desc->keyPattern()));
         } else {
-            index = new RocksStandardIndex(_db.get(), _getIdentPrefix(ident), ident.toString(),
-                                           Ordering::make(desc->keyPattern()));
+            auto si = new RocksStandardIndex(_db.get(), _getIdentPrefix(ident), ident.toString(),
+                                             Ordering::make(desc->keyPattern()));
+            if (rocksGlobalOptions.singleDeleteIndex) {
+                si->enableSingleDelete();
+            }
+            index = si;
         }
         {
             stdx::lock_guard<stdx::mutex> lk(_identObjectMapMutex);

--- a/src/rocks_global_options.cpp
+++ b/src/rocks_global_options.cpp
@@ -84,7 +84,8 @@ namespace mongo {
         rocksOptions
             .addOptionChaining("storage.rocksdb.singleDeleteIndex",
                                "rocksdbSingleDeleteIndex", moe::Bool,
-                               "If true, RocksDB will use SingleDelete method for unindex")
+                               "This is still experimental. "
+                               "Use this only if you know what you're doing")
             .setDefault(moe::Value(false));
 
         return options->addSection(rocksOptions);

--- a/src/rocks_global_options.cpp
+++ b/src/rocks_global_options.cpp
@@ -81,6 +81,11 @@ namespace mongo {
                                moe::Bool,
                                "If true, we will turn on RocksDB's advanced counters")
             .setDefault(moe::Value(false));
+        rocksOptions
+            .addOptionChaining("storage.rocksdb.singleDeleteIndex",
+                               "rocksdbSingleDeleteIndex", moe::Bool,
+                               "If true, RocksDB will use SingleDelete method for unindex")
+            .setDefault(moe::Value(false));
 
         return options->addSection(rocksOptions);
     }
@@ -115,6 +120,11 @@ namespace mongo {
             rocksGlobalOptions.counters =
               params["storage.rocksdb.counters"].as<bool>();
             log() << "Counters: " << rocksGlobalOptions.counters;
+        }
+        if (params.count("storage.rocksdb.singleDeleteIndex")) {
+            rocksGlobalOptions.singleDeleteIndex =
+              params["storage.rocksdb.singleDeleteIndex"].as<bool>();
+            log() << "Use SingleDelete in index: " << rocksGlobalOptions.singleDeleteIndex;
         }
 
         return Status::OK();

--- a/src/rocks_global_options.h
+++ b/src/rocks_global_options.h
@@ -41,7 +41,8 @@ namespace mongo {
             : cacheSizeGB(0),
               maxWriteMBPerSec(1024),
               compression("snappy"),
-              crashSafeCounters(false) {}
+              crashSafeCounters(false),
+              singleDeleteIndex(false) {}
 
         Status add(moe::OptionSection* options);
         Status store(const moe::Environment& params, const std::vector<std::string>& args);
@@ -54,6 +55,7 @@ namespace mongo {
 
         bool crashSafeCounters;
         bool counters;
+        bool singleDeleteIndex;
     };
 
     extern RocksGlobalOptions rocksGlobalOptions;

--- a/src/rocks_index.cpp
+++ b/src/rocks_index.cpp
@@ -808,6 +808,18 @@ namespace mongo {
     void RocksStandardIndex::unindex(OperationContext* txn, const BSONObj& key, const RecordId& loc,
                                      bool dupsAllowed) {
         invariant(dupsAllowed);
+        // When DB parameter failIndexKeyTooLong is set to false,
+        // this method may be called for non-existing
+        // keys with the length exceeding the maximum allowed.
+        // Since such keys cannot be in the storage in any case,
+        // executing the following code results in:
+        // - corruption of index storage size value, and
+        // - an attempt to single-delete non-existing key which may
+        //   potentially lead to consecutive single-deletion of the key.
+        // Filter out long keys to prevent the problems described.
+        if (!checkKeySize(key).isOK()) {
+            return;
+        }
 
         KeyString encodedKey(key, _order, loc);
         std::string prefixedKey(_makePrefixedKey(_prefix, encodedKey));

--- a/src/rocks_index.h
+++ b/src/rocks_index.h
@@ -125,6 +125,11 @@ namespace mongo {
 
         virtual SortedDataBuilderInterface* getBulkBuilder(OperationContext* txn,
                                                            bool dupsAllowed) override;
+
+        void enableSingleDelete() { useSingleDelete = true; }
+
+    private:
+        bool useSingleDelete;
     };
 
 } // namespace mongo


### PR DESCRIPTION
Replace `Delete` with `SingleDelete` in `unindex` method of standard index.
This also required adding a check to disallow multiple consecutive `SingleDelete` calls under some circumstances.
Add config option `rocksdb.storage.singleDeleteIndex` to enable `SingleDelete` behavior.

This is the replacement for https://github.com/mongodb-partners/mongo-rocks/pull/16