### PR TITLE
PSMDB-72 LZ4 compression for MongoRocks is not available

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -1,5 +1,13 @@
 Import("env")
 
+dynamic_syslibdeps = []
+conf = Configure(env)
+
+if conf.CheckLibWithHeader("lz4", ["lz4.h","lz4hc.h"], "C", "LZ4_versionNumber();", autoadd=False ):
+    dynamic_syslibdeps.append("lz4")
+
+conf.Finish()
+
 env.Library(
     target= 'storage_rocks_base',
     source= [
@@ -35,6 +43,7 @@ env.Library(
     SYSLIBDEPS=["rocksdb",
                 "z",
                 "bz2"] #z and bz2 are dependencies for rocks
+               + dynamic_syslibdeps
     )
 
 env.Library(

--- a/src/rocks_engine.cpp
+++ b/src/rocks_engine.cpp
@@ -598,6 +598,10 @@ namespace mongo {
             options.compression_per_level[2] = rocksdb::kZlibCompression;
         } else if (rocksGlobalOptions.compression == "none") {
             options.compression_per_level[2] = rocksdb::kNoCompression;
+        } else if (rocksGlobalOptions.compression == "lz4") {
+            options.compression_per_level[2] = rocksdb::kLZ4Compression;
+        } else if (rocksGlobalOptions.compression == "lz4hc") {
+            options.compression_per_level[2] = rocksdb::kLZ4HCCompression;
         } else {
             log() << "Unknown compression, will use default (snappy)";
             options.compression_per_level[2] = rocksdb::kSnappyCompression;

--- a/src/rocks_global_options.cpp
+++ b/src/rocks_global_options.cpp
@@ -50,8 +50,8 @@ namespace mongo {
         rocksOptions.addOptionChaining("storage.rocksdb.compression", "rocksdbCompression",
                                        moe::String,
                                        "block compression algorithm for collection data "
-                                       "[none|snappy|zlib]")
-            .format("(:?none)|(:?snappy)|(:?zlib)", "(none/snappy/zlib)")
+                                       "[none|snappy|zlib|lz4|lz4hc]")
+            .format("(:?none)|(:?snappy)|(:?zlib)|(:?lz4)|(:?lz4hc)", "(none/snappy/zlib/lz4/lz4hc)")
             .setDefault(moe::Value(std::string("snappy")));
         rocksOptions
             .addOptionChaining(


### PR DESCRIPTION
This patch should be safe to merge after MongoDB bug SERVER-24588 (https://jira.mongodb.org/browse/SERVER-24588) will be fixed