### PR TITLE
PSMDB-81 no need to unindex oversized keys

### DIFF
--- a/src/rocks_index.cpp
+++ b/src/rocks_index.cpp
@@ -699,6 +699,19 @@ namespace mongo {
 
     void RocksUniqueIndex::unindex(OperationContext* txn, const BSONObj& key, const RecordId& loc,
                                    bool dupsAllowed) {
+        // When DB parameter failIndexKeyTooLong is set to false,
+        // this method may be called for non-existing
+        // keys with the length exceeding the maximum allowed.
+        // Since such keys cannot be in the storage in any case,
+        // executing the following code results in:
+        // - corruption of index storage size value, and
+        // - an attempt to single-delete non-existing key which may
+        //   potentially lead to consecutive single-deletion of the key.
+        // Filter out long keys to prevent the problems described.
+        if (!checkKeySize(key).isOK()) {
+            return;
+        }
+
         KeyString encodedKey(_keyStringVersion, key, _order);
         std::string prefixedKey(_makePrefixedKey(_prefix, encodedKey));
 


### PR DESCRIPTION
The issue was fixed in RocksStandardIndex::unindex() by Denis Protivennskiy (see commit 2ce7891).
But the same issue exists in RocksUniqueIndex::unindex(). This patch is to fix it too.
This patch should be cherry-picked to v3.2 branch.