### PR TITLE
Change `RocksEngine::getRecordStore` to return a unique pointer (fixed)

### DIFF
--- a/src/rocks_engine.h
+++ b/src/rocks_engine.h
@@ -84,7 +84,7 @@ namespace mongo {
                                          StringData ident,
                                          const CollectionOptions& options) override;
 
-        virtual RecordStore* getRecordStore(OperationContext* opCtx, StringData ns,
+        virtual std::unique_ptr<RecordStore> getRecordStore(OperationContext* opCtx, StringData ns,
                                             StringData ident,
                                             const CollectionOptions& options) override;
 


### PR DESCRIPTION
(Fixed version of #37)

We recently changed KVEngine::getRecordStore to return a unique pointer rather than a raw pointer to fix a memory leak, which makes the following changes necessary.