### PR TITLE
Fix unittests target when built with --ssl option

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -67,6 +67,8 @@ env.Library(
         ],
     LIBDEPS= [
         'storage_rocks_base',
+        # Temporary crutch since the ssl cleanup is hard coded in background.cpp
+        '$BUILD_DIR/mongo/util/net/network',
         ]
     )
 


### PR DESCRIPTION
(cherry picked from commit 4d6676d9d0bcfcc947d8ee963932e521a66005df)
(cherry picked from commit 55dc02940225ba1cd82129fee71a3448d6bba896)