### PR TITLE
SERVER-27497 Do not rely on obsolete modifications to the global envi…

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -1,5 +1,7 @@
 Import("env")
 
+env = env.Clone()
+
 dynamic_syslibdeps = []
 conf = Configure(env)
 
@@ -7,6 +9,8 @@ if conf.CheckLibWithHeader("lz4", ["lz4.h","lz4hc.h"], "C", "LZ4_versionNumber()
     dynamic_syslibdeps.append("lz4")
 
 conf.Finish()
+
+env.InjectMongoIncludePaths()
 
 env.Library(
     target= 'storage_rocks_base',


### PR DESCRIPTION
…ronment

SConscripts should work on a local copy of the environment. This has been changed in the upstream mongo sources, and a side effect is that some previously (unintentional) global changes (like making the mongo headers available), are now local. The rocks repo needs to now explicitly modify the environment. In order to avoid mutating the global environment, a local Clone should be made.