### PR TITLE
Added option to dynamically change RocksDB options using setParameter

### DIFF
--- a/src/rocks_init.cpp
+++ b/src/rocks_init.cpp
@@ -62,6 +62,7 @@ namespace mongo {
                 auto leaked3 __attribute__((unused)) = new RocksBackupServerParameter(engine);
                 auto leaked4 __attribute__((unused)) = new RocksCompactServerParameter(engine);
                 auto leaked5 __attribute__((unused)) = new RocksCacheSizeParameter(engine);
+                auto leaked6 __attribute__((unused)) = new RocksOptionsParameter(engine);
 
                 return new KVStorageEngine(engine, options);
             }

--- a/src/rocks_parameters.cpp
+++ b/src/rocks_parameters.cpp
@@ -187,6 +187,10 @@ namespace mongo {
     }
 
     Status RocksOptionsParameter::set(const BSONElement& newValueElement) {        
+        // In case the BSON element is not a string, the conversion will fail, 
+        // raising an exception catched by the outer layer.
+        // Which will generate an error message that looks like this:
+        // wrong type for field (rocksdbOptions) 3 != 2        
         return setFromString(newValueElement.String());
     }
 

--- a/src/rocks_parameters.h
+++ b/src/rocks_parameters.h
@@ -99,4 +99,21 @@ namespace mongo {
         Status _set(int newNum);
         RocksEngine* _engine;
     };
+    
+    
+    // We use mongo's setParameter() API to dynamically change the RocksDB options using the SetOptions API
+    // To dynamically change an option, call:
+    // db.adminCommand({setParameter:1, "rocksdbOptions": "someoption=1; someoption2=3"})
+    class RocksOptionsParameter : public ServerParameter {
+        MONGO_DISALLOW_COPYING(RocksOptionsParameter);
+
+    public:
+        RocksOptionsParameter(RocksEngine* engine);
+        virtual void append(OperationContext* txn, BSONObjBuilder& b, const std::string& name);
+        virtual Status set(const BSONElement& newValueElement);
+        virtual Status setFromString(const std::string& str);
+
+    private:
+        RocksEngine* _engine;
+    };
 }


### PR DESCRIPTION
Use can now use:
```db.runCommand({ setParameter: 1, rocksdbOptions: "level0_stop_writes_trigger=90; level0_slowdown_writes_trigger=90" })```
to update parameters dynamically

Or:
```
db.runCommand({ getParameter: 1, "rocksdbOptions": 1})
```
To get parameters values

Note that only from RocksDB 4.13.0 and up if you run set and then get you will get the updated parameters and not the ones from boot.
