### PR TITLE
Added concurrency limit to RocksDB to avoid DoS from queries

### DIFF
--- a/src/rocks_engine.cpp
+++ b/src/rocks_engine.cpp
@@ -189,6 +189,14 @@ namespace mongo {
         private:
             const RocksEngine* _engine;
         };
+        
+        TicketHolder openWriteTransaction(128);
+        RocksTicketServerParameter openWriteTransactionParam(&openWriteTransaction,
+                                                        "rocksdbConcurrentWriteTransactions");
+
+        TicketHolder openReadTransaction(128);
+        RocksTicketServerParameter openReadTransactionParam(&openReadTransaction,
+                                                       "rocksdbConcurrentReadTransactions");
 
     }  // anonymous namespace
 
@@ -316,6 +324,25 @@ namespace mongo {
 
     RocksEngine::~RocksEngine() { cleanShutdown(); }
 
+    void RocksEngine::appendGlobalStats(BSONObjBuilder& b) {
+        BSONObjBuilder bb(b.subobjStart("concurrentTransactions"));
+        {
+            BSONObjBuilder bbb(bb.subobjStart("write"));
+            bbb.append("out", openWriteTransaction.used());
+            bbb.append("available", openWriteTransaction.available());
+            bbb.append("totalTickets", openWriteTransaction.outof());
+            bbb.done();
+        }
+        {
+            BSONObjBuilder bbb(bb.subobjStart("read"));
+            bbb.append("out", openReadTransaction.used());
+            bbb.append("available", openReadTransaction.available());
+            bbb.append("totalTickets", openReadTransaction.outof());
+            bbb.done();
+        }
+        bb.done();
+    }
+    
     RecoveryUnit* RocksEngine::newRecoveryUnit() {
         return new RocksRecoveryUnit(&_transactionEngine, &_snapshotManager, _db.get(),
                                      _counterManager.get(), _compactionScheduler.get(),

--- a/src/rocks_engine.cpp
+++ b/src/rocks_engine.cpp
@@ -67,6 +67,7 @@
 
 #include "rocks_counter_manager.h"
 #include "rocks_global_options.h"
+#include "rocks_parameters.h"
 #include "rocks_record_store.h"
 #include "rocks_recovery_unit.h"
 #include "rocks_index.h"

--- a/src/rocks_engine.cpp
+++ b/src/rocks_engine.cpp
@@ -320,6 +320,8 @@ namespace mongo {
             _journalFlusher = stdx::make_unique<RocksJournalFlusher>(_durabilityManager.get());
             _journalFlusher->go();
         }
+        
+        Locker::setGlobalThrottling(&openReadTransaction, &openWriteTransaction);
     }
 
     RocksEngine::~RocksEngine() { cleanShutdown(); }

--- a/src/rocks_engine.h
+++ b/src/rocks_engine.h
@@ -75,6 +75,8 @@ namespace mongo {
     public:
         RocksEngine(const std::string& path, bool durable);
         virtual ~RocksEngine();
+        
+        static void appendGlobalStats(BSONObjBuilder& b);
 
         virtual RecoveryUnit* newRecoveryUnit() override;
 

--- a/src/rocks_engine.h
+++ b/src/rocks_engine.h
@@ -52,7 +52,6 @@
 #include "rocks_transaction.h"
 #include "rocks_snapshot_manager.h"
 #include "rocks_durability_manager.h"
-#include "rocks_parameters.h"
 
 namespace rocksdb {
     class ColumnFamilyHandle;

--- a/src/rocks_engine.h
+++ b/src/rocks_engine.h
@@ -52,6 +52,7 @@
 #include "rocks_transaction.h"
 #include "rocks_snapshot_manager.h"
 #include "rocks_durability_manager.h"
+#include "rocks_parameters.h"
 
 namespace rocksdb {
     class ColumnFamilyHandle;

--- a/src/rocks_parameters.h
+++ b/src/rocks_parameters.h
@@ -116,4 +116,20 @@ namespace mongo {
     private:
         RocksEngine* _engine;
     };
+    
+    // ServerParameter to limit concurrency, to prevent thousands of threads running
+    // concurrent searches and thus blocking the entire DB.
+    class RocksTicketServerParameter : public ServerParameter {
+        MONGO_DISALLOW_COPYING(TicketServerParameter);
+
+    public:
+        RocksTicketServerParameter(TicketHolder* holder, const std::string& name);
+        virtual void append(OperationContext* txn, BSONObjBuilder& b, const std::string& name);
+        virtual Status set(const BSONElement& newValueElement);
+        virtual Status setFromString(const std::string& str);
+
+    private:
+        Status _set(int newNum);
+        TicketHolder* _holder;
+    };
 }

--- a/src/rocks_parameters.h
+++ b/src/rocks_parameters.h
@@ -120,7 +120,7 @@ namespace mongo {
     // ServerParameter to limit concurrency, to prevent thousands of threads running
     // concurrent searches and thus blocking the entire DB.
     class RocksTicketServerParameter : public ServerParameter {
-        MONGO_DISALLOW_COPYING(TicketServerParameter);
+        MONGO_DISALLOW_COPYING(RocksTicketServerParameter);
 
     public:
         RocksTicketServerParameter(TicketHolder* holder, const std::string& name);

--- a/src/rocks_parameters.h
+++ b/src/rocks_parameters.h
@@ -28,6 +28,7 @@
 
 #include "mongo/base/disallow_copying.h"
 #include "mongo/db/server_parameters.h"
+#include "mongo/util/concurrency/ticketholder.h"
 
 #include "rocks_engine.h"
 

--- a/src/rocks_server_status.cpp
+++ b/src/rocks_server_status.cpp
@@ -206,6 +206,8 @@ namespace mongo {
 
         return bob.obj();
     }
+    
+    RocksEngine::appendGlobalStats(bob);
 
 }  // namespace mongo
 

--- a/src/rocks_server_status.cpp
+++ b/src/rocks_server_status.cpp
@@ -203,11 +203,11 @@ namespace mongo {
 
           bob.append("counters", countersObjBuilder.obj());
         }
+        
+        RocksEngine::appendGlobalStats(bob);
 
         return bob.obj();
     }
-    
-    RocksEngine::appendGlobalStats(bob);
 
 }  // namespace mongo
 


### PR DESCRIPTION
The concept is copied from WT:
https://github.com/mongodb/mongo/blob/master/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp#L290

Currently, there is no protection in MongoRocks from multiple queries ( > 1000 or whatever).
What could happen (and has happened to us in some cases) is that in a flood of queries, every query (that's how mongo works) will open a thread trying to read. That could stack up to thousands of threads, causing more context switches than actual work, which causes the database to basically halt.
In WT they are protecting it by using Mongo's global lock, that creates a queue of readers/writers whenever such a flood occurs, instead of letting everyone in.

The parameter is configurable in runtime and also monitorable using serverStatus()
