### PR TITLE
V3.2 add deleted count compaction threshold

### DIFF
--- a/src/rocks_record_store.cpp
+++ b/src/rocks_record_store.cpp
@@ -622,7 +622,7 @@ namespace mongo {
 
         if (_isOplog) {
             if ((_oplogSinceLastCompaction.minutes() >= kOplogCompactEveryMins) || 
-            (_oplogKeyTracker->getDeletedSinceCompaction() >= kOplogCompactEveryDeletedRecrods)) {
+            (_oplogKeyTracker->getDeletedSinceCompaction() >= kOplogCompactEveryDeletedRecords)) {
                 log() << "Scheduling oplog compactions. time since last " << _oplogSinceLastCompaction.minutes() <<
                     " deleted since last " << _oplogKeyTracker->getDeletedSinceCompaction();
                 _oplogSinceLastCompaction.reset();

--- a/src/rocks_record_store.cpp
+++ b/src/rocks_record_store.cpp
@@ -257,6 +257,7 @@ namespace mongo {
         }
         void deleteKey(RocksRecoveryUnit* ru, const RecordId& loc) {
             ru->writeBatch()->Delete(RocksRecordStore::_makePrefixedKey(_prefix, loc));
+            _deletedKeysSinceCompaction++;
         }
         rocksdb::Iterator* newIterator(RocksRecoveryUnit* ru) {
             return ru->NewIterator(_prefix, true);
@@ -265,9 +266,16 @@ namespace mongo {
             uint32_t size =
                 endian::littleToNative(*reinterpret_cast<const uint32_t*>(value.data()));
             return static_cast<int>(size);
+        }        
+        void resetDeletedSinceCompaction() {
+            _deletedKeysSinceCompaction = 0;
         }
+        long long getDeletedSinceCompaction() {
+            return _deletedKeysSinceCompaction;
+        }        
 
     private:
+        std::atomic<long long> _deletedKeysSinceCompaction;
         std::string _prefix;
     };
 
@@ -613,8 +621,10 @@ namespace mongo {
         txn->setRecoveryUnit(realRecoveryUnit, realRUstate);
 
         if (_isOplog) {
-            if (_oplogSinceLastCompaction.minutes() >= kOplogCompactEveryMins) {
-                log() << "Scheduling oplog compactions";
+            if ((_oplogSinceLastCompaction.minutes() >= kOplogCompactEveryMins) || 
+            (_oplogKeyTracker->getDeletedSinceCompaction() >= kOplogCompactEveryDeletedRecrods)) {
+                log() << "Scheduling oplog compactions. time since last " << _oplogSinceLastCompaction.minutes() <<
+                    " deleted since last " << _oplogKeyTracker->getDeletedSinceCompaction();
                 _oplogSinceLastCompaction.reset();
                 // schedule compaction for oplog
                 std::string oldestAliveKey(_makePrefixedKey(_prefix, _cappedOldestKeyHint));
@@ -627,6 +637,8 @@ namespace mongo {
                 begin = rocksdb::Slice(oplogKeyTrackerPrefix);
                 end = rocksdb::Slice(oldestAliveKey);
                 rocksdb::experimental::SuggestCompactRange(_db, &begin, &end);
+                
+                _oplogKeyTracker->resetDeletedSinceCompaction();
             }
         }
 

--- a/src/rocks_record_store.h
+++ b/src/rocks_record_store.h
@@ -293,7 +293,7 @@ namespace mongo {
         // compact oplog every 30 min
         static const int kOplogCompactEveryMins = 30;
         // compact oplog every 500K deletes
-        static const int kOplogCompactEveryDeletedRecrods = 500000;
+        static const int kOplogCompactEveryDeletedRecords = 500000;
 
         // invariant: there is no live records earlier than _cappedOldestKeyHint. There might be
         // some records that are dead after _cappedOldestKeyHint.

--- a/src/rocks_record_store.h
+++ b/src/rocks_record_store.h
@@ -292,7 +292,7 @@ namespace mongo {
         Timer _oplogSinceLastCompaction;
         // compact oplog every 30 min
         static const int kOplogCompactEveryMins = 30;
-        // compact oplog every 100K deletes
+        // compact oplog every 500K deletes
         static const int kOplogCompactEveryDeletedRecrods = 500000;
 
         // invariant: there is no live records earlier than _cappedOldestKeyHint. There might be

--- a/src/rocks_record_store.h
+++ b/src/rocks_record_store.h
@@ -292,6 +292,8 @@ namespace mongo {
         Timer _oplogSinceLastCompaction;
         // compact oplog every 30 min
         static const int kOplogCompactEveryMins = 30;
+        // compact oplog every 100K deletes
+        static const int kOplogCompactEveryDeletedRecrods = 500000;
 
         // invariant: there is no live records earlier than _cappedOldestKeyHint. There might be
         // some records that are dead after _cappedOldestKeyHint.


### PR DESCRIPTION
Currently, oplog compaction is only time based (const of 30 mins).
In write intensive environments, even setting it to 1 minute may sometimes not be enough.
I added another threshold which is the deleted key count for compaction.
During my tests, with a pretty decent insert rate (~60-80K IPS, 400B docs) this is performing a lot better than previously without all the tombstones that were there without the patch.

I also improved the log, so that you will know if time or deleted # was the compaction trigger.

I set the threshold constant to 500K records. I did some tests and this seems to be a good number. If you have any other tests that you would like to run in order to validate, let me know.