### PR TITLE
SERVER-22541: Remove ScopedTransaction. 

### DIFF
--- a/src/rocks_record_store_mongod.cpp
+++ b/src/rocks_record_store_mongod.cpp
@@ -81,8 +81,6 @@ namespace mongo {
                 const auto txn = cc().makeOperationContext();
 
                 try {
-                    ScopedTransaction transaction(txn.get(), MODE_IX);
-
                     AutoGetDb autoDb(txn.get(), _ns.db(), MODE_IX);
                     Database* db = autoDb.getDb();
                     if (!db) {


### PR DESCRIPTION
The class has been removed and its functionality is now covered by GlobalLock.