### PR TITLE
PSMDB-126 Add index and collection name in dup key error message

### DIFF
--- a/src/rocks_engine.cpp
+++ b/src/rocks_engine.cpp
@@ -446,8 +446,8 @@ namespace mongo {
         RocksIndexBase* index;
         if (desc->unique()) {
             index = new RocksUniqueIndex(_db.get(), _getIdentPrefix(ident), ident.toString(),
-                                         Ordering::make(desc->keyPattern()), desc->isPartial());
-
+                                         Ordering::make(desc->keyPattern()), desc->parentNS(),
+                                         desc->indexName(), desc->isPartial());
         } else {
             auto si = new RocksStandardIndex(_db.get(), _getIdentPrefix(ident), ident.toString(),
                                              Ordering::make(desc->keyPattern()));

--- a/src/rocks_index.h
+++ b/src/rocks_index.h
@@ -94,6 +94,7 @@ namespace mongo {
     class RocksUniqueIndex : public RocksIndexBase {
     public:
         RocksUniqueIndex(rocksdb::DB* db, std::string prefix, std::string ident, Ordering order,
+                         std::string collectionNamespace, std::string indexName,
                          bool partial = false);
 
         virtual Status insert(OperationContext* txn, const BSONObj& key, const RecordId& loc,
@@ -108,6 +109,8 @@ namespace mongo {
         virtual SortedDataBuilderInterface* getBulkBuilder(OperationContext* txn,
                                                            bool dupsAllowed) override;
     private:
+        std::string _collectionNamespace;
+        std::string _indexName;
         const bool _partial;
     };
 

--- a/src/rocks_index_test.cpp
+++ b/src/rocks_index_test.cpp
@@ -68,7 +68,8 @@ namespace mongo {
 
         std::unique_ptr<SortedDataInterface> newSortedDataInterface(bool unique) {
             if (unique) {
-                return stdx::make_unique<RocksUniqueIndex>(_db.get(), "prefix", "ident", _order);
+                return stdx::make_unique<RocksUniqueIndex>(_db.get(), "prefix", "ident", _order,
+                                                           "test.rocks", "testIndex");
             } else {
                 return stdx::make_unique<RocksStandardIndex>(_db.get(), "prefix", "ident", _order);
             }


### PR DESCRIPTION
* Add index and collection name in dup key error message
* Pass needed parameters by value in UniqueBulkBuilder and RocksUniqueIndex

 Conflicts:
	src/rocks_engine.cpp
	src/rocks_index.cpp
	src/rocks_index.h