### PR TITLE
SERVER-27727 Hide idle threads in hang analyzer (mongo-rocks)

### DIFF
--- a/src/rocks_engine.cpp
+++ b/src/rocks_engine.cpp
@@ -64,6 +64,7 @@
 #include "mongo/platform/endian.h"
 #include "mongo/stdx/memory.h"
 #include "mongo/util/background.h"
+#include "mongo/util/concurrency/idle_thread_block.h"
 #include "mongo/util/log.h"
 #include "mongo/util/processinfo.h"
 
@@ -102,6 +103,7 @@ namespace mongo {
                     ms = 100;
                 }
 
+                MONGO_IDLE_THREAD_BLOCK;
                 sleepmillis(ms);
             }
             LOG(1) << "stopping " << name() << " thread";

--- a/src/rocks_record_store.cpp
+++ b/src/rocks_record_store.cpp
@@ -56,6 +56,7 @@
 #include "mongo/stdx/memory.h"
 #include "mongo/util/assert_util.h"
 #include "mongo/util/background.h"
+#include "mongo/util/concurrency/idle_thread_block.h"
 #include "mongo/util/log.h"
 #include "mongo/util/mongoutils/str.h"
 
@@ -127,8 +128,11 @@ namespace mongo {
         Client::initThread("RocksOplogJournalThread");
         while (true) {
             stdx::unique_lock<stdx::mutex> lk(_uncommittedRecordIdsMutex);
-            _opsWaitingForJournalCV.wait(
-                lk, [&] { return _shuttingDown || !_opsWaitingForJournal.empty(); });
+            {
+                MONGO_IDLE_THREAD_BLOCK;
+                _opsWaitingForJournalCV.wait(
+                    lk, [&] { return _shuttingDown || !_opsWaitingForJournal.empty(); });
+            }
 
             if (_shuttingDown) {
                 return;


### PR DESCRIPTION
This is mongo-rocks version of commits:
https://github.com/mongodb/mongo/commit/63d1f4c049587e7923a1154fc31f29bc190316df
https://github.com/mongodb/mongo/commit/8056164a27fcaa1429744f9f2ff039a3d8c39b6f