### PR TITLE
Fix the build with RocksDB master

### DIFF
--- a/src/rocks_recovery_unit.cpp
+++ b/src/rocks_recovery_unit.cpp
@@ -174,13 +174,13 @@ namespace mongo {
                     rocksdb::SetPerfLevel(rocksdb::kEnableCount);
                 }
                 _rocksdbSkippedDeletionsInitial =
-                    rocksdb::perf_context.internal_delete_skipped_count;
+                    rocksdb::get_perf_context()->internal_delete_skipped_count;
             }
             void endOp() {
                 if (_compactionScheduler == nullptr) {
                     return;
                 }
-                int skippedDeletionsOp = rocksdb::perf_context.internal_delete_skipped_count -
+                int skippedDeletionsOp = rocksdb::get_perf_context()->internal_delete_skipped_count -
                                          _rocksdbSkippedDeletionsInitial;
                 if (skippedDeletionsOp >=
                     RocksCompactionScheduler::getSkippedDeletionsThreshold()) {

--- a/src/rocks_recovery_unit.cpp
+++ b/src/rocks_recovery_unit.cpp
@@ -39,6 +39,7 @@
 #include <rocksdb/options.h>
 // Temporary fix for https://github.com/facebook/rocksdb/pull/2336#issuecomment-303226208
 #define ROCKSDB_SUPPORT_THREAD_LOCAL
+#include <rocksdb/version.h>
 #include <rocksdb/perf_context.h>
 #include <rocksdb/write_batch.h>
 #include <rocksdb/utilities/write_batch_with_index.h>


### PR DESCRIPTION
RocksDB commit https://github.com/facebook/rocksdb/commit/7f6c02dda16471c2ed3318e9e7156f2b8d13bf46 hides the perf_context global variable. This fixes the build.