### PR TITLE
PSMDB-127 Implementation of compaction on the background thread

### DIFF
--- a/src/rocks_compaction_scheduler.cpp
+++ b/src/rocks_compaction_scheduler.cpp
@@ -28,26 +28,159 @@
 
 #define MONGO_LOG_DEFAULT_COMPONENT ::mongo::logger::LogComponent::kStorage
 
+#include <deque>
+
 #include "mongo/platform/basic.h"
 
 #include "rocks_compaction_scheduler.h"
 
-#include <atomic>
-#include <map>
-#include <memory>
-#include <string>
-
-// for invariant()
+#include "mongo/db/client.h"
+#include "mongo/stdx/condition_variable.h"
 #include "mongo/stdx/mutex.h"
 #include "mongo/util/assert_util.h"
+#include "mongo/util/background.h"
 #include "mongo/util/log.h"
 #include "rocks_util.h"
 
+#include <rocksdb/convenience.h>
 #include <rocksdb/db.h>
 #include <rocksdb/experimental.h>
 #include <rocksdb/slice.h>
 
 namespace mongo {
+
+    class CompactionBackgroundJob : public BackgroundJob {
+    public:
+        CompactionBackgroundJob(rocksdb::DB* db);
+        virtual ~CompactionBackgroundJob();
+
+        // schedule compact range operation for execution in _compactionThread
+        Status scheduleCompactOp(const std::string& begin = std::string(), const std::string& end = std::string(),
+                                 bool rangeDropped = false);
+
+    private:
+        // struct with compaction operation data
+        struct CompactOp {
+            void doCompact(rocksdb::DB* db) const;
+
+            std::string _start_str;
+            std::string _end_str;
+            bool _rangeDropped;
+        };
+
+        static const char * const _name;
+
+        // BackgroundJob
+        virtual std::string name() const override { return _name; }
+        virtual void run() override;
+
+        rocksdb::DB* _db;  // not owned
+
+        bool _compactionThreadRunning = true;
+        stdx::mutex _compactionMutex;
+        stdx::condition_variable _compactionWakeUp;
+        std::deque<CompactOp> _compactionQueue;
+    };
+
+    const char* const CompactionBackgroundJob::_name = "RocksCompactionThread";
+
+    CompactionBackgroundJob::CompactionBackgroundJob(rocksdb::DB* db)
+        : _db(db) {
+        go();
+    }
+
+    CompactionBackgroundJob::~CompactionBackgroundJob() {
+        {
+            stdx::lock_guard<stdx::mutex> lk(_compactionMutex);
+            _compactionThreadRunning = false;
+            _compactionQueue.clear();
+        }
+        _compactionWakeUp.notify_one();
+        wait();
+    }
+
+    namespace {
+        template <class T>
+        class unlock_guard {
+        public:
+          unlock_guard(T& lk) : lk_(lk) {
+            lk_.unlock();
+          }
+
+          ~unlock_guard() {
+            lk_.lock();
+          }
+
+          unlock_guard(const unlock_guard&) = delete;
+          unlock_guard& operator=(const unlock_guard&) = delete;
+
+        private:
+          T& lk_;
+        };
+    }
+
+    void CompactionBackgroundJob::run() {
+        Client::initThread(_name);
+        stdx::unique_lock<stdx::mutex> lk(_compactionMutex);
+        while (_compactionThreadRunning) {
+            // check if we have something to compact
+            if (_compactionQueue.empty())
+                _compactionWakeUp.wait(lk);
+            else {
+                // get item from queue
+                const CompactOp op(std::move(_compactionQueue.front()));
+                _compactionQueue.pop_front();
+                // unlock mutex for the time of compaction
+                unlock_guard<decltype(lk)> rlk(lk);
+                // do compaction
+                op.doCompact(_db);
+            }
+        }
+        lk.unlock();
+        LOG(1) << "compaction thread terminating" << std::endl;
+    }
+
+    Status CompactionBackgroundJob::scheduleCompactOp(const std::string& begin, const std::string& end, bool rangeDropped) {
+        {
+            stdx::lock_guard<stdx::mutex> lk(_compactionMutex);
+            _compactionQueue.push_back({begin, end, rangeDropped});
+        }
+        _compactionWakeUp.notify_one();
+        return Status::OK();
+    }
+
+    void CompactionBackgroundJob::CompactOp::doCompact(rocksdb::DB* db) const {
+        rocksdb::Slice start_slice(_start_str);
+        rocksdb::Slice end_slice(_end_str);
+
+        rocksdb::Slice* start = !_start_str.empty() ? &start_slice : nullptr;
+        rocksdb::Slice* end = !_end_str.empty() ? &end_slice : nullptr;
+
+        LOG(1) << "starting compaction of range: "
+              << (start ? start->ToString(true) : "<begin>") << " .. "
+              << (end ? end->ToString(true) : "<end>")
+              << " (_rangeDropped is " << _rangeDropped << ")";
+
+        if (_rangeDropped) {
+            auto s = rocksdb::DeleteFilesInRange(db, db->DefaultColumnFamily(), start, end);
+            if (!s.ok()) {
+                log() << "failed to delete files in range: " << s.ToString();
+            }
+        }
+
+        rocksdb::CompactRangeOptions compact_options;
+        compact_options.bottommost_level_compaction = rocksdb::BottommostLevelCompaction::kForce;
+        compact_options.exclusive_manual_compaction = false;
+        auto s = db->CompactRange(compact_options, start, end);
+        if (!s.ok()) {
+            log() << "failed to compact range: " << s.ToString();
+        }
+    }
+
+    RocksCompactionScheduler::RocksCompactionScheduler(rocksdb::DB* db)
+        : _compactionJob(new CompactionBackgroundJob(db)) {
+        _timer.reset();
+    }
 
     void RocksCompactionScheduler::reportSkippedDeletionsAboveThreshold(const std::string& prefix) {
         bool schedule = false;
@@ -61,12 +194,34 @@ namespace mongo {
         if (schedule) {
             log() << "Scheduling compaction to clean up tombstones for prefix "
                   << rocksdb::Slice(prefix).ToString(true);
-            // we schedule compaction now
-            std::string nextPrefix(rocksGetNextPrefix(prefix));
-            rocksdb::Slice begin(prefix), end(nextPrefix);
-            // ignore error
-            rocksdb::experimental::SuggestCompactRange(_db, &begin, &end);
+            // we schedule compaction now (ignoring error)
+            compactPrefix(prefix);
         }
+    }
+
+    RocksCompactionScheduler::~RocksCompactionScheduler() {
+        // We need this to avoid incomplete type deletion
+        _compactionJob.reset();
+    }
+
+    Status RocksCompactionScheduler::compactAll() {
+        return compactRange(std::string(), std::string());
+    }
+
+    Status RocksCompactionScheduler::compactRange(const std::string& start, const std::string& end) {
+        return _compactionJob->scheduleCompactOp(start, end);
+    }
+
+    Status RocksCompactionScheduler::compactPrefix(const std::string& prefix) {
+        return compactRange(prefix, rocksGetNextPrefix(prefix));
+    }
+
+    Status RocksCompactionScheduler::compactDroppedRange(const std::string& start, const std::string& end) {
+        return _compactionJob->scheduleCompactOp(start, end, true);
+    }
+
+    Status RocksCompactionScheduler::compactDroppedPrefix(const std::string& prefix) {
+        return compactDroppedRange(prefix, rocksGetNextPrefix(prefix));
     }
 
 }

--- a/src/rocks_compaction_scheduler.cpp
+++ b/src/rocks_compaction_scheduler.cpp
@@ -95,6 +95,7 @@ namespace mongo {
             _compactionThreadRunning = false;
             _compactionQueue.clear();
         }
+        rocksdb::CancelAllBackgroundWork(_db);
         _compactionWakeUp.notify_one();
         wait();
     }

--- a/src/rocks_compaction_scheduler.h
+++ b/src/rocks_compaction_scheduler.h
@@ -57,8 +57,8 @@ namespace mongo {
         Status compactRange(const std::string& begin, const std::string& end);
         Status compactPrefix(const std::string& prefix);
         Status compactDroppedRange(const std::string& begin, const std::string& end,
-                                   const std::function<void()>& cleanup);
-        Status compactDroppedPrefix(const std::string& prefix, const std::function<void()>& cleanup);
+                                   const std::function<void(bool)>& cleanup);
+        Status compactDroppedPrefix(const std::string& prefix, const std::function<void(bool)>& cleanup);
 
     private:
         stdx::mutex _lock;

--- a/src/rocks_compaction_scheduler.h
+++ b/src/rocks_compaction_scheduler.h
@@ -28,6 +28,7 @@
 
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <string>
 
@@ -55,8 +56,9 @@ namespace mongo {
         Status compactAll();
         Status compactRange(const std::string& begin, const std::string& end);
         Status compactPrefix(const std::string& prefix);
-        Status compactDroppedRange(const std::string& begin, const std::string& end);
-        Status compactDroppedPrefix(const std::string& prefix);
+        Status compactDroppedRange(const std::string& begin, const std::string& end,
+                                   const std::function<void()>& cleanup);
+        Status compactDroppedPrefix(const std::string& prefix, const std::function<void()>& cleanup);
 
     private:
         stdx::mutex _lock;

--- a/src/rocks_compaction_scheduler.h
+++ b/src/rocks_compaction_scheduler.h
@@ -28,32 +28,37 @@
 
 #pragma once
 
-#include <atomic>
-#include <set>
-#include <unordered_map>
 #include <memory>
 #include <string>
-#include <list>
 
 #include <rocksdb/db.h>
 #include <rocksdb/slice.h>
 
+#include "mongo/base/status.h"
 #include "mongo/stdx/mutex.h"
 #include "mongo/util/timer.h"
 
 namespace mongo {
 
+    class CompactionBackgroundJob;
+
     class RocksCompactionScheduler {
     public:
-        RocksCompactionScheduler(rocksdb::DB* db) : _db(db) { _timer.reset(); }
+        RocksCompactionScheduler(rocksdb::DB* db);
+        ~RocksCompactionScheduler();
 
         static int getSkippedDeletionsThreshold() { return kSkippedDeletionsThreshold; }
 
         void reportSkippedDeletionsAboveThreshold(const std::string& prefix);
 
-    private:
-        rocksdb::DB* _db;  // not owned
+        // schedule compact range operation for execution in _compactionThread
+        Status compactAll();
+        Status compactRange(const std::string& begin, const std::string& end);
+        Status compactPrefix(const std::string& prefix);
+        Status compactDroppedRange(const std::string& begin, const std::string& end);
+        Status compactDroppedPrefix(const std::string& prefix);
 
+    private:
         stdx::mutex _lock;
         // protected by _lock
         Timer _timer;
@@ -63,5 +68,8 @@ namespace mongo {
         // We'll compact the prefix if any operation on the prefix reports more than 50.000
         // deletions it had to skip over (this is about 10ms extra overhead)
         static const int kSkippedDeletionsThreshold = 50000;
+
+        // thread for async execution of range compactions
+        std::unique_ptr<CompactionBackgroundJob> _compactionJob;
     };
 }

--- a/src/rocks_engine.cpp
+++ b/src/rocks_engine.cpp
@@ -434,11 +434,13 @@ namespace mongo {
         std::unique_ptr<RocksRecordStore> recordStore =
             options.capped
                 ? stdx::make_unique<RocksRecordStore>(
-                      ns, ident, _db.get(), _counterManager.get(), _durabilityManager.get(), prefix,
+                      ns, ident, _db.get(), _counterManager.get(), _durabilityManager.get(),
+                      _compactionScheduler.get(), prefix,
                       true, options.cappedSize ? options.cappedSize : 4096,  // default size
                       options.cappedMaxDocs ? options.cappedMaxDocs : -1)
                 : stdx::make_unique<RocksRecordStore>(ns, ident, _db.get(), _counterManager.get(),
-                                                      _durabilityManager.get(), prefix);
+                                                      _durabilityManager.get(), _compactionScheduler.get(),
+                                                      prefix);
 
         {
             stdx::lock_guard<stdx::mutex> lk(_identObjectMapMutex);

--- a/src/rocks_engine.cpp
+++ b/src/rocks_engine.cpp
@@ -161,7 +161,7 @@ namespace mongo {
 
             // IgnoreSnapshots is available since RocksDB 4.3
 #if defined(ROCKSDB_MAJOR) && (ROCKSDB_MAJOR > 4 || (ROCKSDB_MAJOR == 4 && ROCKSDB_MINOR >= 3))
-            virtual bool IgnoreSnapshots() const { return true; }
+            virtual bool IgnoreSnapshots() const override { return true; }
 #endif
 
             virtual const char* Name() const { return "PrefixDeletingCompactionFilter"; }

--- a/src/rocks_engine.cpp
+++ b/src/rocks_engine.cpp
@@ -341,6 +341,7 @@ namespace mongo {
                  iter->Valid() && iter->key().starts_with(kDroppedPrefix); iter->Next()) {
                 invariantRocksOK(iter->status());
                 rocksdb::Slice prefix(iter->key());
+                std::string prefixkey(prefix.ToString());
                 prefix.remove_prefix(kDroppedPrefix.size());
                 prefixIter->Seek(prefix);
                 invariantRocksOK(iter->status());
@@ -357,9 +358,16 @@ namespace mongo {
                     LOG(1) << "compacting dropped prefix: " << prefix.ToString(true);
                     auto s = _compactionScheduler->compactDroppedPrefix(
                                 prefix.ToString(),
-                                [=]{
-                                    stdx::lock_guard<stdx::mutex> lk(_droppedPrefixesMutex);
-                                    _droppedPrefixes.erase(int_prefix);
+                                [=] (bool opSucceeded) {
+                                    {
+                                        stdx::lock_guard<stdx::mutex> lk(_droppedPrefixesMutex);
+                                        _droppedPrefixes.erase(int_prefix);
+                                    }
+                                    if (opSucceeded) {
+                                        rocksdb::WriteOptions syncOptions;
+                                        syncOptions.sync = true;
+                                        _db->Delete(syncOptions, prefixkey);
+                                    }
                                 });
                     if (!s.isOK()) {
                         log() << "failed to schedule compaction for prefix " << prefix.ToString(true);
@@ -547,12 +555,19 @@ namespace mongo {
         for (auto& prefix : prefixesToDrop) {
             auto s = _compactionScheduler->compactDroppedPrefix(
                         prefix,
-                        [=]{
-                            uint32_t int_prefix;
-                            bool ok = extractPrefix(prefix, &int_prefix);
-                            invariant(ok);
-                            stdx::lock_guard<stdx::mutex> lk(_droppedPrefixesMutex);
-                            _droppedPrefixes.erase(int_prefix);
+                        [=] (bool opSucceeded) {
+                            {
+                                uint32_t int_prefix;
+                                bool ok = extractPrefix(prefix, &int_prefix);
+                                invariant(ok);
+                                stdx::lock_guard<stdx::mutex> lk(_droppedPrefixesMutex);
+                                _droppedPrefixes.erase(int_prefix);
+                            }
+                            if (opSucceeded) {
+                                rocksdb::WriteOptions syncOptions;
+                                syncOptions.sync = true;
+                                _db->Delete(syncOptions, kDroppedPrefix + prefix);
+                            }
                         });
             if (!s.isOK()) {
                 log() << "failed to schedule compaction for prefix " << rocksdb::Slice(prefix).ToString(true);

--- a/src/rocks_engine.h
+++ b/src/rocks_engine.h
@@ -154,6 +154,8 @@ namespace mongo {
 
         RocksTransactionEngine* getTransactionEngine() { return &_transactionEngine; }
 
+        RocksCompactionScheduler* getCompactionScheduler() const { return _compactionScheduler.get(); }
+
         int getMaxWriteMBPerSec() const { return _maxWriteMBPerSec; }
         void setMaxWriteMBPerSec(int maxWriteMBPerSec);
 

--- a/src/rocks_parameters.cpp
+++ b/src/rocks_parameters.cpp
@@ -115,8 +115,7 @@ namespace mongo {
     }
 
     Status RocksCompactServerParameter::setFromString(const std::string& str) {
-        auto s = rocksdb::experimental::SuggestCompactRange(_engine->getDB(), nullptr, nullptr);
-        return rocksToMongoStatus(s);
+        return _engine->getCompactionScheduler()->compactAll();
     }
 
     RocksCacheSizeParameter::RocksCacheSizeParameter(RocksEngine* engine)

--- a/src/rocks_record_store.cpp
+++ b/src/rocks_record_store.cpp
@@ -61,6 +61,7 @@
 
 #include "rocks_counter_manager.h"
 #include "rocks_durability_manager.h"
+#include "rocks_compaction_scheduler.h"
 #include "rocks_engine.h"
 #include "rocks_recovery_unit.h"
 #include "rocks_util.h"
@@ -278,11 +279,13 @@ namespace mongo {
     RocksRecordStore::RocksRecordStore(StringData ns, StringData id, rocksdb::DB* db,
                                        RocksCounterManager* counterManager,
                                        RocksDurabilityManager* durabilityManager,
+                                       RocksCompactionScheduler* compactionScheduler,
                                        std::string prefix, bool isCapped, int64_t cappedMaxSize,
                                        int64_t cappedMaxDocs, CappedCallback* cappedCallback)
         : RecordStore(ns),
           _db(db),
           _counterManager(counterManager),
+          _compactionScheduler(compactionScheduler),
           _prefix(std::move(prefix)),
           _isCapped(isCapped),
           _cappedMaxSize(cappedMaxSize),

--- a/src/rocks_record_store.cpp
+++ b/src/rocks_record_store.cpp
@@ -627,16 +627,13 @@ namespace mongo {
                 _oplogSinceLastCompaction.reset();
                 // schedule compaction for oplog
                 std::string oldestAliveKey(_makePrefixedKey(_prefix, _cappedOldestKeyHint));
-                rocksdb::Slice begin(_prefix), end(oldestAliveKey);
-                rocksdb::experimental::SuggestCompactRange(_db, &begin, &end);
+                _compactionScheduler->compactRange(_prefix, oldestAliveKey);
 
                 // schedule compaction for oplog tracker
                 std::string oplogKeyTrackerPrefix(rocksGetNextPrefix(_prefix));
                 oldestAliveKey = _makePrefixedKey(oplogKeyTrackerPrefix, _cappedOldestKeyHint);
-                begin = rocksdb::Slice(oplogKeyTrackerPrefix);
-                end = rocksdb::Slice(oldestAliveKey);
-                rocksdb::experimental::SuggestCompactRange(_db, &begin, &end);
-                
+                _compactionScheduler->compactRange(oplogKeyTrackerPrefix, oldestAliveKey);
+
                 _oplogKeyTracker->resetDeletedSinceCompaction();
             }
         }

--- a/src/rocks_record_store.h
+++ b/src/rocks_record_store.h
@@ -58,6 +58,7 @@ namespace mongo {
 
     class RocksCounterManager;
     class RocksDurabilityManager;
+    class RocksCompactionScheduler;
     class RocksRecoveryUnit;
     class RocksOplogKeyTracker;
     class RocksRecordStore;
@@ -106,7 +107,9 @@ namespace mongo {
     public:
         RocksRecordStore(StringData ns, StringData id, rocksdb::DB* db,
                          RocksCounterManager* counterManager,
-                         RocksDurabilityManager* durabilityManager, std::string prefix,
+                         RocksDurabilityManager* durabilityManager,
+                         RocksCompactionScheduler* compactionScheduler,
+                         std::string prefix,
                          bool isCapped = false, int64_t cappedMaxSize = -1,
                          int64_t cappedMaxDocs = -1, CappedCallback* cappedDeleteCallback = NULL);
 
@@ -270,6 +273,7 @@ namespace mongo {
 
         rocksdb::DB* _db;                      // not owned
         RocksCounterManager* _counterManager;  // not owned
+        RocksCompactionScheduler* _compactionScheduler;  // not owned
         std::string _prefix;
 
         const bool _isCapped;

--- a/src/rocks_record_store_test.cpp
+++ b/src/rocks_record_store_test.cpp
@@ -42,6 +42,7 @@
 #include "mongo/unittest/unittest.h"
 #include "mongo/unittest/temp_dir.h"
 
+#include "rocks_compaction_scheduler.h"
 #include "rocks_record_store.h"
 #include "rocks_recovery_unit.h"
 #include "rocks_transaction.h"
@@ -63,6 +64,7 @@ namespace mongo {
             _db.reset(db);
             _counterManager.reset(new RocksCounterManager(_db.get(), true));
             _durabilityManager.reset(new RocksDurabilityManager(_db.get(), true));
+            _compactionScheduler.reset(new RocksCompactionScheduler(_db.get()));
         }
 
         virtual std::unique_ptr<RecordStore> newNonCappedRecordStore() {
@@ -70,7 +72,8 @@ namespace mongo {
         }
         std::unique_ptr<RecordStore> newNonCappedRecordStore(const std::string& ns) {
             return stdx::make_unique<RocksRecordStore>(ns, "1", _db.get(), _counterManager.get(),
-                                                       _durabilityManager.get(), "prefix");
+                                                       _durabilityManager.get(),
+                                                       _compactionScheduler.get(), "prefix");
         }
 
         std::unique_ptr<RecordStore> newCappedRecordStore(int64_t cappedMaxSize,
@@ -82,7 +85,9 @@ namespace mongo {
                                                           int64_t cappedMaxSize,
                                                           int64_t cappedMaxDocs) {
             return stdx::make_unique<RocksRecordStore>(ns, "1", _db.get(), _counterManager.get(),
-                                                       _durabilityManager.get(), "prefix", true,
+                                                       _durabilityManager.get(),
+                                                       _compactionScheduler.get(),
+                                                       "prefix", true,
                                                        cappedMaxSize, cappedMaxDocs);
         }
 
@@ -104,6 +109,7 @@ namespace mongo {
         RocksSnapshotManager _snapshotManager;
         std::unique_ptr<RocksDurabilityManager> _durabilityManager;
         std::unique_ptr<RocksCounterManager> _counterManager;
+        std::unique_ptr<RocksCompactionScheduler> _compactionScheduler;
     };
 
     std::unique_ptr<HarnessHelper> newHarnessHelper() {


### PR DESCRIPTION
The change introduces background compaction thread with `DeleteFilesInRange` and bottommost level compaction enabled.

This is the first part of the changes which will be followed by more code improvements where compaction-related code is completely moved to the `RocksCompactionScheduler`.