### PR TITLE
Fix RocksRecoveryUnit commit issus

### DIFF
--- a/src/rocks_recovery_unit.cpp
+++ b/src/rocks_recovery_unit.cpp
@@ -250,9 +250,7 @@ namespace mongo {
     }
 
     void RocksRecoveryUnit::commitUnitOfWork() {
-        if (_writeBatch.GetWriteBatch()->Count() > 0) {
-            _commit();
-        }
+        _commit();
 
         try {
             for (Changes::const_iterator it = _changes.begin(), end = _changes.end(); it != end;


### PR DESCRIPTION
this check ``` _writeBatch.GetWriteBatch()->Count() > 0 ``` makes ``` _deltaCounters ``` lost

flowing code doesn't work .
```
void RocksRecordStore::updateStats(OperationContext* txn, long long numRecordsInc, long long dataSizeInc) {
    WriteUnitOfWork wuow(txn);
    auto ru = RocksRecoveryUnit::getRocksRecoveryUnit(txn);
    ru->incrementCounter(_numRecordsKey, &_numRecords, numRecordsInc);
    ru->incrementCounter(_dataSizeKey, &_dataSize, dataSizeInc);
    wuow.commit();
}
```