### PR TITLE
Fix Cursor performance issus

### DIFF
--- a/src/rocks_record_store.cpp
+++ b/src/rocks_record_store.cpp
@@ -586,7 +586,7 @@ namespace mongo {
                 iter->Next();
             }
 
-            if (!iter->status().ok()) {
+            if (!iter->Valid() && !iter->status().ok()) {
                 log() << "RocksDB iterator failure when trying to delete capped, ignoring: "
                       << redact(iter->status().ToString());
             }
@@ -1064,7 +1064,7 @@ namespace mongo {
         _skipNextAdvance = false;
         int64_t locStorage;
         _iterator->Seek(RocksRecordStore::_makeKey(_lastLoc, &locStorage));
-        invariantRocksOK(_iterator->status());
+        invariantRocksOK(_iterator->Valid() ? rocksdb::Status::OK() : _iterator->status());
 
         if (_forward) {
             // If _skipNextAdvance is true we landed after where we were. Return our new location on
@@ -1190,7 +1190,6 @@ namespace mongo {
     }
 
     boost::optional<Record> RocksRecordStore::Cursor::curr() {
-        invariantRocksOK(_iterator->status());
         if (!_iterator->Valid()) {
             _eof = true;
             return {};

--- a/src/rocks_record_store.cpp
+++ b/src/rocks_record_store.cpp
@@ -1196,6 +1196,7 @@ namespace mongo {
 
     boost::optional<Record> RocksRecordStore::Cursor::curr() {
         if (!_iterator->Valid()) {
+            invariantRocksOK(_iterator->status());
             _eof = true;
             return {};
         }


### PR DESCRIPTION
MergingIterator::status() is unfriendly to performance , we should not call it frequently .
on bulkload mode , we may have many many lv0 sst , it will make Cursor stuck .

https://github.com/facebook/rocksdb/blob/9b11d4345a0f01fc3de756e01460bf1b0446f326/table/merging_iterator.cc#L271