### PR TITLE
V3.2

### DIFF
--- a/src/rocks_record_store.cpp
+++ b/src/rocks_record_store.cpp
@@ -1045,7 +1045,6 @@ namespace mongo {
             _lastLoc = startIterator;
             iterator();
             _skipNextAdvance = true;
-
         }
     }
 

--- a/src/rocks_record_store.cpp
+++ b/src/rocks_record_store.cpp
@@ -756,7 +756,7 @@ namespace mongo {
         }
 
         return stdx::make_unique<Cursor>(txn, _db, _prefix, _cappedVisibilityManager, forward,
-                                         _isCapped);
+                                         _isCapped, _cappedOldestKeyHint);
     }
 
     Status RocksRecordStore::truncate(OperationContext* txn) {
@@ -1027,7 +1027,8 @@ namespace mongo {
             std::string prefix,
             std::shared_ptr<CappedVisibilityManager> cappedVisibilityManager,
             bool forward,
-            bool isCapped)
+            bool isCapped,
+            RecordId startIterator)
         : _txn(txn),
           _db(db),
           _prefix(std::move(prefix)),
@@ -1037,6 +1038,15 @@ namespace mongo {
           _readUntilForOplog(RocksRecoveryUnit::getRocksRecoveryUnit(txn)->getOplogReadTill()) {
         _currentSequenceNumber =
           RocksRecoveryUnit::getRocksRecoveryUnit(txn)->snapshot()->GetSequenceNumber();
+          
+        if (!startIterator.isNull() && !_readUntilForOplog.isNull() && forward) {
+            // This is a hack to speed up first record retrieval from the oplog
+            _needFirstSeek = false;
+            _lastLoc = startIterator;
+            iterator();
+            _skipNextAdvance = true;
+
+        }
     }
 
     // requires !_eof

--- a/src/rocks_record_store.h
+++ b/src/rocks_record_store.h
@@ -222,7 +222,7 @@ namespace mongo {
         public:
             Cursor(OperationContext* txn, rocksdb::DB* db, std::string prefix,
                    std::shared_ptr<CappedVisibilityManager> cappedVisibilityManager,
-                   bool forward, bool _isCapped);
+                   bool forward, bool _isCapped, RecordId startIterator);
 
             boost::optional<Record> next() final;
             boost::optional<Record> seekExact(const RecordId& id) final;


### PR DESCRIPTION
Implemented for oplog only, maybe could be extended for any type of capped collection, but didn't want to overshoot there.