### PR TITLE
SERVER-30313 RocksRecordStore::isInRecordIdOrder() should return true

### DIFF
--- a/src/rocks_record_store.h
+++ b/src/rocks_record_store.h
@@ -126,6 +126,8 @@ namespace mongo {
                                      BSONObjBuilder* extraInfo = NULL,
                                      int infoLevel = 0 ) const;
 
+        virtual bool isInRecordIdOrder() const override { return true; }
+
         // CRUD related
 
         virtual RecordData dataFor( OperationContext* opCtx, const RecordId& loc ) const;


### PR DESCRIPTION
@igorcanadi, I believe RocksRecordStore cursor retrieves its documents in RecordId order, so `isInRecordIdOrder()` should be true?