### PR TITLE
SERVER-23935 Disable oplog sampling in queryable backup mode

### DIFF
--- a/src/rocks_record_store_mongod.cpp
+++ b/src/rocks_record_store_mongod.cpp
@@ -145,9 +145,9 @@ namespace mongo {
             return false;
         }
 
-        if (storageGlobalParams.repair) {
+        if (storageGlobalParams.repair || storageGlobalParams.readOnly) {
             LOG(1) << "not starting RocksRecordStoreThread for " << ns
-                   << " because we are in repair";
+                   << " because we are either in repair or read-only mode";
             return false;
         }
 


### PR DESCRIPTION
In queryable backup mode the oplog truncation would never occur. Hence oplog sampling
is disabled this mode.