### PR TITLE
SERVER-30790: Have RocksServerStatusSection take a Global IS lock

### DIFF
--- a/src/rocks_server_status.cpp
+++ b/src/rocks_server_status.cpp
@@ -40,6 +40,7 @@
 
 #include "mongo/base/checked_cast.h"
 #include "mongo/bson/bsonobjbuilder.h"
+#include "mongo/db/concurrency/d_concurrency.h"
 #include "mongo/util/assert_util.h"
 #include "mongo/util/scopeguard.h"
 
@@ -71,6 +72,7 @@ namespace mongo {
 
     BSONObj RocksServerStatusSection::generateSection(OperationContext* txn,
                                                       const BSONElement& configElement) const {
+        Lock::GlobalLock lk(txn->lockState(), LockMode::MODE_IS, UINT_MAX);
 
         BSONObjBuilder bob;
 


### PR DESCRIPTION
This has already been in master: https://github.com/mongodb-partners/mongo-rocks/pull/110
But it was also ported back in 3.4.9