### PR TITLE
PSMDB-164 Ignore missing ident in dropIdent

### DIFF
--- a/src/rocks_engine.h
+++ b/src/rocks_engine.h
@@ -163,6 +163,7 @@ namespace mongo {
     private:
         Status _createIdentPrefix(StringData ident);
         std::string _getIdentPrefix(StringData ident);
+        std::string _tryGetIdentPrefix(StringData ident);
 
         rocksdb::Options _options() const;
 


### PR DESCRIPTION
It may happen that ident has already been dropped and this info
persisted separately, but upper layer metadata didn't persist because
of system crash on standalone instance with default acknowledgement
behavior.