### PR TITLE
PSMDB-164 Ignore missing ident in dropIdent

### DIFF
--- a/src/rocks_engine.h
+++ b/src/rocks_engine.h
@@ -166,6 +166,7 @@ namespace mongo {
     private:
         Status _createIdent(StringData ident, BSONObjBuilder* configBuilder);
         BSONObj _getIdentConfig(StringData ident);
+        BSONObj _tryGetIdentConfig(StringData ident);
         std::string _extractPrefix(const BSONObj& config);
 
         rocksdb::Options _options() const;


### PR DESCRIPTION
It may happen that ident has already been dropped and this info
persisted separately, but upper layer metadata didn't persist because
of system crash on standalone instance with default acknowledgement
behavior.