### PR TITLE
Cherrypick SERVER-32249 to v3.6 branch

### DIFF
--- a/src/rocks_recovery_unit.cpp
+++ b/src/rocks_recovery_unit.cpp
@@ -292,10 +292,10 @@ namespace mongo {
         return Status::OK();
     }
 
-    boost::optional<SnapshotName> RocksRecoveryUnit::getMajorityCommittedSnapshot() const {
+    boost::optional<Timestamp> RocksRecoveryUnit::getMajorityCommittedSnapshot() const {
         if (!_readFromMajorityCommittedSnapshot)
             return {};
-        return SnapshotName(_snapshotManager->getCommittedSnapshot().get()->name);
+        return Timestamp(_snapshotManager->getCommittedSnapshot().get()->name);
     }
 
     SnapshotId RocksRecoveryUnit::getSnapshotId() const { return SnapshotId(_mySnapshotId); }

--- a/src/rocks_recovery_unit.h
+++ b/src/rocks_recovery_unit.h
@@ -98,7 +98,7 @@ namespace mongo {
             return _readFromMajorityCommittedSnapshot;
         }
 
-        boost::optional<SnapshotName> getMajorityCommittedSnapshot() const final;
+        boost::optional<Timestamp> getMajorityCommittedSnapshot() const final;
 
         virtual void* writingPtr(void* data, size_t len) { invariant(!"don't call writingPtr"); }
 

--- a/src/rocks_snapshot_manager.cpp
+++ b/src/rocks_snapshot_manager.cpp
@@ -45,10 +45,10 @@ namespace mongo {
         return Status::OK();
     }
 
-    void RocksSnapshotManager::setCommittedSnapshot(const SnapshotName& name, Timestamp ts) {
+    void RocksSnapshotManager::setCommittedSnapshot(const Timestamp& ts) {
         stdx::lock_guard<stdx::mutex> lock(_mutex);
 
-        uint64_t nameU64 = name.asU64();
+        uint64_t nameU64 = ts.asULL();
         invariant(!_committedSnapshot || *_committedSnapshot <= nameU64);
         _committedSnapshot = nameU64;
     }

--- a/src/rocks_snapshot_manager.h
+++ b/src/rocks_snapshot_manager.h
@@ -60,7 +60,7 @@ public:
     }
 
     Status prepareForCreateSnapshot(OperationContext* opCtx) final;
-    void setCommittedSnapshot(const SnapshotName& name, Timestamp ts) final;
+    void setCommittedSnapshot(const Timestamp& ts) final;
     void cleanupUnneededSnapshots() final;
     void dropAllSnapshots() final;
 


### PR DESCRIPTION
The equivalent patch in MongoDB community was backported to 3.6. This PR allows MongoDB 3.6 to compile against MongoRocks 3.6.