### PR TITLE
PSMDB-191 take into account dropped prefixes when calculating _maxPrefix

### DIFF
--- a/src/rocks_compaction_scheduler.h
+++ b/src/rocks_compaction_scheduler.h
@@ -68,7 +68,7 @@ namespace mongo {
 
         rocksdb::CompactionFilterFactory* createCompactionFilterFactory() const;
         std::unordered_set<uint32_t> getDroppedPrefixes() const;
-        void loadDroppedPrefixes(rocksdb::Iterator* iter);
+        uint32_t loadDroppedPrefixes(rocksdb::Iterator* iter);
         Status dropPrefixesAtomic(const std::vector<std::string>& prefixesToDrop,
                                   const rocksdb::WriteOptions& syncOptions,
                                   rocksdb::WriteBatch& wb);

--- a/src/rocks_engine.cpp
+++ b/src/rocks_engine.cpp
@@ -255,7 +255,8 @@ namespace mongo {
 
         // start compaction thread and load dropped prefixes
         _compactionScheduler->start(_db.get());
-        _compactionScheduler->loadDroppedPrefixes(iter.get());
+        auto maxDroppedPrefix = _compactionScheduler->loadDroppedPrefixes(iter.get());
+        _maxPrefix = std::max(_maxPrefix, maxDroppedPrefix);
 
         _durabilityManager.reset(new RocksDurabilityManager(_db.get(), _durable));
 


### PR DESCRIPTION
This closes very serious data integrity issue.
It is hard to ensure but it probably fixes issue #79 and issue #80 .
Should be ported to all version branches.