### PR TITLE
Advance oldestTimestamp when setStableTimestamp called (#152)

### DIFF
--- a/src/rocks_engine.cpp
+++ b/src/rocks_engine.cpp
@@ -630,7 +630,16 @@ namespace mongo {
 
     }  // namespace
 
-    void RocksEngine::setStableTimestamp(Timestamp stableTimestamp) {}
+    void RocksEngine::setStableTimestamp(Timestamp stableTimestamp) {
+        if (!_keepDataHistory || stableTimestamp.isNull()) {
+            return;
+        }
+        // Communicate to Rocksdb that it can clean up timestamp data earlier than the timestamp
+        // provided.  No future queries will need point-in-time reads at a timestamp prior to the one
+        // provided here.
+        const bool force = false;
+        setOldestTimestamp(stableTimestamp, force);
+    }
 
     void RocksEngine::setInitialDataTimestamp(Timestamp initialDataTimestamp) {}
 


### PR DESCRIPTION
By YCSB benchmarking, it's confirmed that loading 10 000 000 records into mongorocks 4.0 finally succeeds. `CleanCommittedKeys` thread seems to be working well, and memory is not overwhelmed with excessive committed keys any more.