### PR TITLE
fix memory issue and build error

### DIFF
--- a/src/rocks_record_store.cpp
+++ b/src/rocks_record_store.cpp
@@ -915,7 +915,7 @@ namespace mongo {
         RocksRecoveryUnit* ru = RocksRecoveryUnit::getRocksRecoveryUnit(opCtx);
 
         std::string valueStorage;
-        auto status = ru->Get(_cf, _makePrefixedKey(prefix, loc), &valueStorage);
+        auto status = ru->Get(cf, _makePrefixedKey(prefix, loc), &valueStorage);
         if (status.IsNotFound()) {
             return RecordData(nullptr, 0);
         }


### PR DESCRIPTION
when running the mongos js test suite, replica_sets_ill_secondaries_jscore_passthrough, there is probability
memory issue which lead mongod crash.
```c++
    uint32_t RocksCompactionScheduler::loadDroppedPrefixes(rocksdb::Iterator* iter,
                                                           std::vector<rocksdb::ColumnFamilyHandle*> cfs) {
        invariant(iter);
        const uint32_t rocksdbSkippedDeletionsInitial =
            (uint32_t)get_internal_delete_skipped_count();
        int dropped_count = 0;
        uint32_t int_prefix = 0;
        for (iter->Seek(kDroppedPrefix); iter->Valid() && iter->key().starts_with(kDroppedPrefix);
             iter->Next()) {
            invariantRocksOK(iter->status());
            rocksdb::Slice prefix(iter->key());
            prefix.remove_prefix(kDroppedPrefix.size());

            // let's instruct the compaction scheduler to compact dropped prefix
            ++dropped_count;
            bool ok = extractPrefix(prefix, &int_prefix);
            invariant(ok);
            {
                stdx::lock_guard<stdx::mutex> lk(_droppedPrefixesMutex);
                _droppedPrefixes.emplace(int_prefix, BSONObj(iter->value().data()));
                                                       ^^^^^^^^^^^^^^^^^^^^^^ Here should copy the bsonobj data then we can save it into _droppedPrefixes map.
            }

```

* 