### PR TITLE
Remove Timestamp info from user key in oplog compaction filter

### DIFF
--- a/src/rocks_compaction_scheduler.cpp
+++ b/src/rocks_compaction_scheduler.cpp
@@ -79,8 +79,12 @@ namespace mongo {
             virtual bool Filter(int level, const rocksdb::Slice& key,
                                 const rocksdb::Slice& existing_value, std::string* new_value,
                                 bool* value_changed) const {
-                bool filter = (key.compare(rocksdb::Slice(_until)) <= 0 &&
-                               key.compare(rocksdb::Slice(_from)) >= 0);
+                const rocksdb::Slice stripUserKey =
+                    rocksdb::TOComparator::StripTimestampFromUserKey(
+                        key, rocksdb::TOComparator::TimestampSize());
+
+                bool filter = (stripUserKey.compare(rocksdb::Slice(_until)) <= 0 &&
+                               stripUserKey.compare(rocksdb::Slice(_from)) >= 0);
                 if (filter) {
                     _compactionScheduler->addOplogCompactRemoved();
                 } else {

--- a/src/totdb/totransaction_db.h
+++ b/src/totdb/totransaction_db.h
@@ -84,6 +84,8 @@ class TOComparator : public Comparator {
   TOComparator()
       : Comparator(sizeof(RocksTimeStamp)), cmp_without_ts_(BytewiseComparator()) {
   }
+
+  static size_t TimestampSize() { return sizeof(RocksTimeStamp); }
   const char* Name() const override { return "TOComparator"; }
 
   void FindShortSuccessor(std::string*) const override {}
@@ -131,13 +133,13 @@ class TOComparator : public Comparator {
     }
   }
 
- private:
   static const Slice StripTimestampFromUserKey(const Slice& user_key, size_t ts_sz) {
     Slice ret = user_key;
     ret.remove_suffix(ts_sz);
     return ret;
   }
 
+  private:
   const Comparator* cmp_without_ts_;
 };
 


### PR DESCRIPTION
TOTransactionDB enables timestamp, so when oplog compaction filter, you need to delete timestamp from user key