### PR TITLE
remove f.largestkey timestamp

### DIFF
--- a/src/rocks_record_store.h
+++ b/src/rocks_record_store.h
@@ -277,6 +277,7 @@ namespace mongo {
         static rocksdb::Slice _makeKey(const RecordId& loc, int64_t* storage);
         static std::string _makePrefixedKey(const std::string& prefix, const RecordId& loc);
         Timestamp _prefixedKeyToTimestamp(const std::string& key) const;
+        Timestamp _prefixedKeyToTimestamp(const rocksdb::Slice& key) const;
 
         void _changeNumRecords(OperationContext* opCtx, int64_t amount);
         void _increaseDataSize(OperationContext* opCtx, int64_t amount);


### PR DESCRIPTION
Because the latest version of rocksdb supports timestamp,
the resulting f.largestkey contains timestamp information.
For oplog reclaim operation, we only need to compare the userkey,
and we don't need the timestamp inside the rocksdb key,
so we should delete it.