### PR TITLE
use fakeCompator to skip oplog cf trim operation

### DIFF
--- a/src/rocks_engine.h
+++ b/src/rocks_engine.h
@@ -301,7 +301,7 @@ namespace mongo {
         StorageEngine::OldestActiveTransactionTimestampCallback
             _oldestActiveTransactionTimestampCallback;
 
-        rocksdb::Options _options(bool isOplog) const;
+        rocksdb::Options _options(bool isOplog, bool trimHisotry) const;
 
         void _initDatabase();
 

--- a/src/rocks_record_store.cpp
+++ b/src/rocks_record_store.cpp
@@ -60,6 +60,7 @@
 #include "mongo/util/log.h"
 #include "mongo/util/str.h"
 
+#include "mongo/db/modules/rocks/src/totdb/totransaction.h"
 #include "rocks_compaction_scheduler.h"
 #include "rocks_counter_manager.h"
 #include "rocks_durability_manager.h"

--- a/src/totdb/totransaction_db_impl.cpp
+++ b/src/totdb/totransaction_db_impl.cpp
@@ -213,11 +213,6 @@ Status TOTransactionDB::Open(const DBOptions& db_options,
 
   if (trimHistory) {
     invariant(trim_cfds.size() > 0);
-    for (const auto& cfd : trim_cfds) {
-      if (cfd.options.comparator == nullptr || cfd.options.comparator->timestamp_size() == 0) {
-        return Status::InvalidArgument("invalid comparator");
-      }
-    }
     
     std::string trim_ts;
     // step1: get stableTs


### PR DESCRIPTION
The rollback logic at the mongo-server level calls the rtt(rollback to timestamp) function of the storage engine layer.
This requires user data rollback, but oplog cannot be rolled back. However, at present, the rollback operation of rocksdb is done at the opendb time,
and no parameters can be set to decide which cf needs to be rolled back and which cf cannot be rolled back.
Inside rocksdb, it is only based on the timestamp turned on at the cf time to decide whether to roll back.
Therefore, in order to meet the oplog non-roll policy required by the upper level of mongo,
we temporarily set oplog cf not support ts to make rocksdb skip the rollback behavior of oplog cf.