### PR TITLE
remove _db, _oplogManger, _snapshotManger, _compactionSCheduler, _dur…

### DIFF
--- a/src/rocks_compaction_scheduler.cpp
+++ b/src/rocks_compaction_scheduler.cpp
@@ -460,6 +460,8 @@ namespace mongo {
         _compactionJob.reset(new CompactionBackgroundJob(db, this));
     }
 
+    void RocksCompactionScheduler::stop() { _compactionJob.reset(); }
+
     void RocksCompactionScheduler::reportSkippedDeletionsAboveThreshold(rocksdb::ColumnFamilyHandle* cf,
                                                                         const std::string& prefix) {
         bool schedule = false;

--- a/src/rocks_compaction_scheduler.h
+++ b/src/rocks_compaction_scheduler.h
@@ -70,6 +70,7 @@ namespace mongo {
         ~RocksCompactionScheduler();
 
         void start(rocksdb::TOTransactionDB* db, rocksdb::ColumnFamilyHandle* cf);
+        void stop();
 
         static int getSkippedDeletionsThreshold() { return kSkippedDeletionsThreshold; }
 

--- a/src/rocks_engine.cpp
+++ b/src/rocks_engine.cpp
@@ -479,11 +479,7 @@ namespace mongo {
         _oldestActiveTransactionTimestampCallback = std::move(callback);
     };
 
-    RecoveryUnit* RocksEngine::newRecoveryUnit() {
-        return new RocksRecoveryUnit(_db.get(), _oplogManager.get(), &_snapshotManager,
-                                     _compactionScheduler.get(),
-                                     _durabilityManager.get(), _durable, this);
-    }
+    RecoveryUnit* RocksEngine::newRecoveryUnit() { return new RocksRecoveryUnit(_durable, this); }
 
     Status RocksEngine::createRecordStore(OperationContext* opCtx, StringData ns, StringData ident,
                                           const CollectionOptions& options) {
@@ -1025,7 +1021,6 @@ namespace mongo {
                           << initialDataTS.toString() << ", Stable timestamp: " << stableTS.toString());
         }
 
-
         invariant(!_oplogManager->isRunning());
         LOG_FOR_ROLLBACK(0) << "RocksEngine::RecoverToStableTimestamp oplogManager is halt.";
 
@@ -1045,8 +1040,8 @@ namespace mongo {
         _durabilityManager.reset();
         LOG_FOR_ROLLBACK(0) << "RocksEngine::RecoverToStableTimestamp shutting down durabilityManager";
 
-        _compactionScheduler.reset();
-        LOG_FOR_ROLLBACK(0) << "RocksEngine::RecoverToStableTimestamp shutting down _compactionScheduler";
+        _compactionScheduler->stop();
+        LOG_FOR_ROLLBACK(0) << "RocksEngine::RecoverToStableTimestamp stop _compactionScheduler";
 
         // close db
         _defaultCf.reset();
@@ -1054,10 +1049,15 @@ namespace mongo {
         _db.reset();
         LOG_FOR_ROLLBACK(0) << "RocksEngine::RecoverToStableTimestamp shutting down rocksdb";
 
+        // compactionScheduler should be create before initDatabase, because
+        // options.compactionFactor need compactionScheduler
+        _compactionScheduler.reset(new RocksCompactionScheduler());
+        LOG_FOR_ROLLBACK(0)
+            << "RocksEngine::RecoverToStableTimestamp shutting down _compactionScheduler";
+
         _initDatabase();
         LOG_FOR_ROLLBACK(0) << "RocksEngine::RecoverToStableTimestamp open rocksdb";
 
-        _compactionScheduler.reset(new RocksCompactionScheduler());
         _compactionScheduler->start(_db.get(), _defaultCf.get());
 
         _durabilityManager.reset(
@@ -1081,6 +1081,8 @@ namespace mongo {
         }
         _counterManager.reset(new RocksCounterManager(_db.get(), _defaultCf.get(),
                                                       rocksGlobalOptions.crashSafeCounters));
+        opCtx->setRecoveryUnit(std::unique_ptr<RecoveryUnit>(newRecoveryUnit()),
+                               WriteUnitOfWork::RecoveryUnitState::kNotInUnitOfWork);
 
         // oplogManager will be oppend by oplog record store is open, no need open here
 

--- a/src/rocks_engine.h
+++ b/src/rocks_engine.h
@@ -135,6 +135,8 @@ namespace mongo {
             return (SnapshotManager*)&_snapshotManager;
         }
 
+        RocksSnapshotManager* getRocksSnapshotManager() { return &_snapshotManager; }
+
         void setJournalListener(JournalListener* jl);
 
         void setStableTimestamp(Timestamp stableTimestamp, bool force) override;

--- a/src/rocks_index_test.cpp
+++ b/src/rocks_index_test.cpp
@@ -80,11 +80,7 @@ namespace mongo {
             }
 
             std::unique_ptr<RecoveryUnit> newRecoveryUnit() final {
-                return stdx::make_unique<RocksRecoveryUnit>(
-                    _engine.getDB(), _engine.getOplogManager(),
-                    checked_cast<RocksSnapshotManager*>(_engine.getSnapshotManager()),
-                    _engine.getCompactionScheduler(),
-                    _engine.getDurabilityManager(), true /* durale */, &_engine);
+                return stdx::make_unique<RocksRecoveryUnit>(true /* durale */, &_engine);
             }
 
         private:

--- a/src/rocks_recovery_unit.cpp
+++ b/src/rocks_recovery_unit.cpp
@@ -256,18 +256,8 @@ namespace mongo {
 
     std::atomic<int> RocksRecoveryUnit::_totalLiveRecoveryUnits(0);
 
-    RocksRecoveryUnit::RocksRecoveryUnit(rocksdb::TOTransactionDB* db,
-                                         RocksOplogManager* oplogManager,
-                                         RocksSnapshotManager* snapshotManager,
-                                         RocksCompactionScheduler* compactionScheduler,
-                                         RocksDurabilityManager* durabilityManager,
-                                         bool durable, RocksEngine* engine)
-        : _db(db),
-          _oplogManager(oplogManager),
-          _snapshotManager(snapshotManager),
-          _compactionScheduler(compactionScheduler),
-          _durabilityManager(durabilityManager),
-          _durable(durable),
+    RocksRecoveryUnit::RocksRecoveryUnit(bool durable, RocksEngine* engine)
+        : _durable(durable),
           _areWriteUnitOfWorksBanned(false),
           _isTimestamped(false),
           _timestampReadSource(ReadSource::kUnset),
@@ -302,7 +292,7 @@ namespace mongo {
         }
 
         if (notifyDone) {
-            _durabilityManager->notifyPreparedUnitOfWorkHasCommittedOrAborted();
+            getDurabilityManager()->notifyPreparedUnitOfWorkHasCommittedOrAborted();
         }
 
         try {
@@ -339,7 +329,7 @@ namespace mongo {
         }
 
         if (notifyDone) {
-            _durabilityManager->notifyPreparedUnitOfWorkHasCommittedOrAborted();
+            getDurabilityManager()->notifyPreparedUnitOfWorkHasCommittedOrAborted();
         }
         try {
             for (Changes::const_reverse_iterator it = _changes.rbegin(), end = _changes.rend();
@@ -393,7 +383,7 @@ namespace mongo {
 
     bool RocksRecoveryUnit::waitUntilDurable() {
         invariant(!_inUnitOfWork(), toString(_state));
-        _durabilityManager->waitUntilDurable(false);
+        getDurabilityManager()->waitUntilDurable(false);
         return true;
     }
 
@@ -487,7 +477,7 @@ namespace mongo {
 
         if (_isTimestamped) {
             if (!_orderedCommit) {
-                _oplogManager->triggerJournalFlush();
+                getOplogManager()->triggerJournalFlush();
             }
             _isTimestamped = false;
         }
@@ -520,7 +510,7 @@ namespace mongo {
 
     Status RocksRecoveryUnit::obtainMajorityCommittedSnapshot() {
         invariant(_timestampReadSource == ReadSource::kMajorityCommitted);
-        auto snapshotName = _snapshotManager->getMinSnapshotForNextCommittedRead();
+        auto snapshotName = getSnapshotManager()->getMinSnapshotForNextCommittedRead();
         if (!snapshotName) {
             return {ErrorCodes::ReadConcernMajorityNotAvailableYet,
                     "Read concern majority reads are currently not possible."};
@@ -604,9 +594,9 @@ namespace mongo {
             case ReadSource::kNoTimestamp: {
                 if (_isOplogReader) {
                     _oplogVisibleTs =
-                        static_cast<std::int64_t>(_oplogManager->getOplogReadTimestamp());
+                        static_cast<std::int64_t>(getOplogManager()->getOplogReadTimestamp());
                 }
-                RocksBeginTxnBlock(_db, &_transaction, _prepareConflictBehavior,
+                RocksBeginTxnBlock(getDB(), &_transaction, _prepareConflictBehavior,
                                    _roundUpPreparedTimestamps)
                     .done();
                 break;
@@ -614,16 +604,19 @@ namespace mongo {
             case ReadSource::kMajorityCommitted: {
                 // We reset _majorityCommittedSnapshot to the actual read timestamp used when the
                 // transaction was started.
-                _majorityCommittedSnapshot = _snapshotManager->beginTransactionOnCommittedSnapshot(
-                    _db, &_transaction, _prepareConflictBehavior, _roundUpPreparedTimestamps);
+                _majorityCommittedSnapshot =
+                    getSnapshotManager()->beginTransactionOnCommittedSnapshot(
+                        getDB(), &_transaction, _prepareConflictBehavior,
+                        _roundUpPreparedTimestamps);
                 break;
             }
             case ReadSource::kLastApplied: {
-                if (_snapshotManager->getLocalSnapshot()) {
-                    _readAtTimestamp = _snapshotManager->beginTransactionOnLocalSnapshot(
-                        _db, &_transaction, _prepareConflictBehavior, _roundUpPreparedTimestamps);
+                if (getSnapshotManager()->getLocalSnapshot()) {
+                    _readAtTimestamp = getSnapshotManager()->beginTransactionOnLocalSnapshot(
+                        getDB(), &_transaction, _prepareConflictBehavior,
+                        _roundUpPreparedTimestamps);
                 } else {
-                    RocksBeginTxnBlock(_db, &_transaction, _prepareConflictBehavior,
+                    RocksBeginTxnBlock(getDB(), &_transaction, _prepareConflictBehavior,
                                        _roundUpPreparedTimestamps)
                         .done();
                 }
@@ -641,7 +634,7 @@ namespace mongo {
                 // Intentionally continue to the next case to read at the _readAtTimestamp.
             }
             case ReadSource::kProvided: {
-                RocksBeginTxnBlock txnOpen(_db, &_transaction, _prepareConflictBehavior,
+                RocksBeginTxnBlock txnOpen(getDB(), &_transaction, _prepareConflictBehavior,
                                            _roundUpPreparedTimestamps);
                 auto status = txnOpen.setReadSnapshot(_readAtTimestamp);
 
@@ -661,9 +654,9 @@ namespace mongo {
     }
 
     Timestamp RocksRecoveryUnit::_beginTransactionAtAllDurableTimestamp() {
-        RocksBeginTxnBlock txnOpen(_db, &_transaction, _prepareConflictBehavior,
+        RocksBeginTxnBlock txnOpen(getDB(), &_transaction, _prepareConflictBehavior,
                                    _roundUpPreparedTimestamps, RoundUpReadTimestamp::kRound);
-        Timestamp txnTimestamp = _oplogManager->fetchAllDurableValue();
+        Timestamp txnTimestamp = getOplogManager()->fetchAllDurableValue();
         auto status = txnOpen.setReadSnapshot(txnTimestamp);
         invariant(status.isOK(), status.reason());
         auto readTimestamp = txnOpen.getTimestamp();
@@ -673,8 +666,8 @@ namespace mongo {
 
     Timestamp RocksRecoveryUnit::_beginTransactionAtNoOverlapTimestamp(
         std::unique_ptr<rocksdb::TOTransaction>* txn) {
-        auto lastApplied = _snapshotManager->getLocalSnapshot();
-        Timestamp allDurable = Timestamp(_oplogManager->fetchAllDurableValue());
+        auto lastApplied = getSnapshotManager()->getLocalSnapshot();
+        Timestamp allDurable = Timestamp(getOplogManager()->fetchAllDurableValue());
 
         // When using timestamps for reads and writes, it's important that readers and writers don't
         // overlap with the timestamps they use. In other words, at any point in the system there
@@ -707,8 +700,8 @@ namespace mongo {
         // should read afterward.
         Timestamp readTimestamp = (lastApplied) ? std::min(*lastApplied, allDurable) : allDurable;
 
-        RocksBeginTxnBlock txnOpen(_db, txn, _prepareConflictBehavior, _roundUpPreparedTimestamps,
-                                   RoundUpReadTimestamp::kRound);
+        RocksBeginTxnBlock txnOpen(getDB(), txn, _prepareConflictBehavior,
+                                   _roundUpPreparedTimestamps, RoundUpReadTimestamp::kRound);
         auto status = txnOpen.setReadSnapshot(readTimestamp);
         fassert(51090, status);
 
@@ -914,7 +907,7 @@ namespace mongo {
         invariant(getTransaction());
         auto it = _transaction->GetIterator(options, cf);
         return new PrefixStrippingIterator(cf, std::move(prefix), _transaction.get(), it,
-                                           isOplog ? nullptr : _compactionScheduler,
+                                           isOplog ? nullptr : getCompactionScheduler(),
                                            std::move(upperBound));
     }
 
@@ -958,5 +951,26 @@ namespace mongo {
 
     RocksRecoveryUnit* RocksRecoveryUnit::getRocksRecoveryUnit(OperationContext* opCtx) {
         return checked_cast<RocksRecoveryUnit*>(opCtx->recoveryUnit());
+    }
+
+    rocksdb::TOTransactionDB* RocksRecoveryUnit::getDB() {
+        invariant(_engine);
+        return _engine->getDB();
+    }
+    RocksOplogManager* RocksRecoveryUnit::getOplogManager() {
+        invariant(_engine);
+        return _engine->getOplogManager();
+    }
+    RocksSnapshotManager* RocksRecoveryUnit::getSnapshotManager() {
+        invariant(_engine);
+        return _engine->getRocksSnapshotManager();
+    }
+    RocksCompactionScheduler* RocksRecoveryUnit::getCompactionScheduler() {
+        invariant(_engine);
+        return _engine->getCompactionScheduler();
+    }
+    RocksDurabilityManager* RocksRecoveryUnit::getDurabilityManager() {
+        invariant(_engine);
+        return _engine->getDurabilityManager();
     }
 }  // namespace mongo


### PR DESCRIPTION
…abilityManager from rocks recover unit

Because rtt cleans historical data in the reopen db way,
there will not be a stable db pointer at the entire mongo-server level.
Because it needs to be reopened, the db pointer has also changed.
Given this logic, we removed the _db, _oplogManger, _snapshotManger, _compactionSCheduler, _durabilityManager
these in the form of naked pointers in the rocks recover unit
and instead fetch them from the rocks engine each time.